### PR TITLE
Removed the global flag from the regular expression.

### DIFF
--- a/lib/json-front-matter.js
+++ b/lib/json-front-matter.js
@@ -3,9 +3,9 @@ module.exports = (function () {
   var
     fs = require( 'fs' ),
     // http://stackoverflow.com/q/1068308 / https://github.com/jxson/front-matter
-    regex = /^(\s*\{\{\{([\s\S]+?)\}\}\}\s*)/gi,
+    regex = /^(\s*\{\{\{([\s\S]+?)\}\}\}\s*)/i,
     attributes, body;
-    
+
   function parseFile ( path, callback ) {
     fs.readFile( path, 'utf-8', function ( err, data ) {
       callback( err, parseString( data ) );


### PR DESCRIPTION
This fixes https://github.com/jsantell/node-json-front-matter/issues/3.

When `parseString` is called consecutively on two strings, the first one being invalid while the second one is valid, the `regexp.exec` call returns a valid match on the first string and the subsequent call with the second string returns null. I believe this is because of the global flag in the regexp, removing that flag fixes the issue.
