### PR TITLE
Remove redundant code

### DIFF
--- a/lib/json-front-matter.js
+++ b/lib/json-front-matter.js
@@ -29,7 +29,6 @@ module.exports = (function () {
       attributes = {};
       body = data;
     }
-    regex.lastIndex = 0;
     return { attributes: attributes, body: body };
   }
 


### PR DESCRIPTION
According to the MDN documentation on `RegExp.lastIndex`:

```
This property is set only if the regular expression used the "g" flag to indicate a global search.
```

However, the `regex` variable does not have the global flag associated with it so this code seems redundant. The global flag _is_ being used to remove "whitespace" but that is not associated with the regular expression in question.

If I am overlooking something we should create tests for this line of code.
